### PR TITLE
Example table matches defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nodecredstash
 ```js
 let Credstash = require('nodecredstash');
 
-let credstash = new Credstash({table: 'credentials-store', awsOpts: {region: 'us-west-2'}});
+let credstash = new Credstash({table: 'credential-store', awsOpts: {region: 'us-west-2'}});
 
 credstash.putSecret({name: 'Death Star vulnerability', secret: 'Exhaust vent', version: 1, context: {rebel: 'true'}})
   .then(() => credstash.getSecret({name: 'Death Star vulnerability', version: 1, context: {rebel: 'true'}})


### PR DESCRIPTION
The example showed credentials-store instead of credential-store, which is the default table name created by credstash.  I lost a few minutes wondering why my IAM role wouldn't allow me to Query or Scan, until I realized the table name did not match.   :) . 