### PR TITLE
add error message from kms when putSecret operation failed

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -130,7 +130,7 @@ module.exports = function (mainConfig) {
           if (err.code == 'NotFoundException') {
             throw err;
           }
-          throw new Error(`Could not generate key using KMS key ${kmsKey}`);
+          throw new Error(`Could not generate key using KMS key ${kmsKey}, error:${JSON.stringify(err, null, 2)}`);
         })
         .then(kmsData => encrypter.encrypt(digest, secret, kmsData))
         .then(data => Object.assign({ name, version }, data))

--- a/js/test/index.spec.js
+++ b/js/test/index.spec.js
@@ -372,7 +372,7 @@ describe('index', () => {
         secret: realOne.plainText,
       })
         .then(res => expect(res).to.not.exist)
-        .catch(err => err.message.should.equal('Could not generate key using KMS key test'));
+        .catch(err => err.message.should.contains('Could not generate key using KMS key test'));
     });
 
     it('should notify of duplicate name/version pairs', () => {


### PR DESCRIPTION
When putSecret operation failed, the error from AWS KMS is not available to the user and this makes troubleshooting not as easy as it could be. 