### PR TITLE
Allow upgraded dependency to pickup security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "aes-js": "^3.1.0",
-    "aws-sdk": "2.171.0",
-    "debug": "3.1.0"
+    "aws-sdk": "^2.171.0",
+    "debug": "^3.1.0"
   }
 }


### PR DESCRIPTION
Upstream projects often release fixes for security vulnerabilities. Specifically, the aws 2.171.0 version is affected by https://snyk.io/vuln/npm:crypto-browserify:20140722 and the newer versions have a fix for it.