### PR TITLE
fix: Use shared KMS client.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class CredStash {
     }: PutSecret,
   ) {
     const version = sanitizeVersion(origVersion, 1);
-    const keyService = new KeyService(new KMSClient({}), kmsKey, context);
+    const keyService = new KeyService(this.#kmsClient, kmsKey, context);
     const sealed = await sealAesCtrLegacy(keyService, secret, digest);
     const data: SecretRecord = Object.assign({ name, version }, sealed);
     try {
@@ -160,7 +160,7 @@ export class CredStash {
     }: GetSecret,
   ) {
     const version = sanitizeVersion(origVersion);
-    const keyService = new KeyService(new KMSClient({}), kmsKey, context);
+    const keyService = new KeyService(this.#kmsClient, kmsKey, context);
 
     let record: SecretRecord;
     if (version) {

--- a/src/lib/dynamoDb.ts
+++ b/src/lib/dynamoDb.ts
@@ -24,7 +24,8 @@ import debugFn from 'debug';
 import { pause } from './utils';
 import {
   NameAndVersionOpts,
-  NameOpts, Opts,
+  NameOpts,
+  Opts,
   QueryOpts,
   SecretRecord,
 } from '../types';


### PR DESCRIPTION
Addresses #38

 I don't know of a reason as to why we weren't using the existing client.  Creating new clients for each call can also lead to issues with open file descriptors.